### PR TITLE
Fix typo in Redis macro

### DIFF
--- a/redis/zbx_export_templates.xml
+++ b/redis/zbx_export_templates.xml
@@ -651,7 +651,7 @@
                     <value>localhost</value>
                 </macro>
                 <macro>
-                    <macro>{$POST}</macro>
+                    <macro>{$PORT}</macro>
                     <value>6379</value>
                 </macro>
             </macros>


### PR DESCRIPTION
Just fix a typo in Redis macro

 - `$POST` -> `$PORT`